### PR TITLE
add LOGGER type to the node types the can generate logs

### DIFF
--- a/scripts/init.bro
+++ b/scripts/init.bro
@@ -41,7 +41,7 @@ export {
         const force_to_disk_log_ids: set[Log::ID] &redef;
 }
 
-redef PS_tcplog::enabled = ( Cluster::local_node_type() == Cluster::MANAGER || Cluster::local_node_type() == Cluster::NONE );
+redef PS_tcplog::enabled = ( Cluster::local_node_type() == Cluster::LOGGER || Cluster::local_node_type() == Cluster::MANAGER || Cluster::local_node_type() == Cluster::NONE );
 
 event bro_init() &priority=-5
         {


### PR DESCRIPTION
Adds the logger node type to the types of nodes that will export logs. When tcplog was first implemented, the logger node type did not even exist in bro.